### PR TITLE
Add try/catch in the `rapidrec.ts`

### DIFF
--- a/src/background.ts
+++ b/src/background.ts
@@ -27,7 +27,9 @@ chrome.runtime.onMessage.addListener(
     );
     onMessage(message, sender, sendResponse)
       .then(() => console.log("Message processed successfully"))
-      .catch((_err) => console.error("Message processed with error"));
+      .catch((err) =>
+        console.error(`Message processed with error: ${(err as Error).message}`)
+      );
   }
 );
 
@@ -42,7 +44,11 @@ chrome.tabs.onActivated.addListener((activeTabInfo: ActiveTabInfo) => {
   );
   onTabChange(activeTabInfo)
     .then(() => console.log("Tab changing processed successfully"))
-    .catch((_err) => console.error("Tab changing processed with error"));
+    .catch((err) =>
+      console.error(
+        `Tab changing processed with error: ${(err as Error).message}`
+      )
+    );
 });
 
 chrome.tabs.onRemoved.addListener((tabId: number, removeInfo: RemoveInfo) => {
@@ -54,5 +60,9 @@ chrome.tabs.onRemoved.addListener((tabId: number, removeInfo: RemoveInfo) => {
   );
   onTabClosing(tabId, removeInfo)
     .then(() => console.log("Tab closing processed successfully"))
-    .catch((_err) => console.error("Tab closing processed with error"));
+    .catch((err) =>
+      console.error(
+        `Tab closing processed with error: ${(err as Error).message}`
+      )
+    );
 });

--- a/src/rapidrec/callbacks.test.ts
+++ b/src/rapidrec/callbacks.test.ts
@@ -164,16 +164,18 @@ describe("onMessage", () => {
     test("{} message", async () => {
       let response: MessageResponse = {} as MessageResponse;
 
-      await onMessage({} as Message, {}, (msgResponse?) => {
-        response = msgResponse ?? ({} as MessageResponse);
-      });
-
-      expect(JSON.stringify(response)).toEqual(
-        JSON.stringify({
-          ...unknownMethodResult,
-          message: "Invalid message with unknown method {}",
+      await expect(
+        onMessage({} as Message, {}, (msgResponse?) => {
+          response = msgResponse ?? ({} as MessageResponse);
         })
-      );
+      ).rejects.toEqual({
+        ...unknownMethodResult,
+        message: "Invalid message with unknown method {}",
+      } as Failure);
+      expect(response).toEqual({
+        ...unknownMethodResult,
+        message: "Invalid message with unknown method {}",
+      } as Failure);
     });
 
     test("Unknown message", async () => {
@@ -185,18 +187,22 @@ describe("onMessage", () => {
       };
       let response: MessageResponse = {} as MessageResponse;
 
-      await onMessage(unknownMessage as Message, {}, (msgResponse?) => {
-        response = msgResponse ?? ({} as MessageResponse);
-      });
-
-      expect(JSON.stringify(response)).toEqual(
-        JSON.stringify({
-          ...unknownMethodResult,
-          message: `Invalid message with unknown method ${JSON.stringify(
-            unknownMessage
-          )}`,
+      await expect(
+        onMessage(unknownMessage as Message, {}, (msgResponse?) => {
+          response = msgResponse ?? ({} as MessageResponse);
         })
-      );
+      ).rejects.toEqual({
+        ...unknownMethodResult,
+        message: `Invalid message with unknown method ${JSON.stringify(
+          unknownMessage
+        )}`,
+      } as Failure);
+      expect(response).toEqual({
+        ...unknownMethodResult,
+        message: `Invalid message with unknown method ${JSON.stringify(
+          unknownMessage
+        )}`,
+      } as Failure);
     });
 
     test("Method throws error", async () => {
@@ -210,18 +216,21 @@ describe("onMessage", () => {
       };
 
       let response: MessageResponse = {} as MessageResponse;
-      await onMessage(msg, {}, (msgResponse?) => {
-        response = msgResponse ?? ({} as MessageResponse);
-      });
 
+      await expect(
+        onMessage(msg, {}, (msgResponse?) => {
+          response = msgResponse ?? ({} as MessageResponse);
+        })
+      ).rejects.toEqual({
+        ...unknownMethodResult,
+        message: "Some error from correct method",
+      } as Failure);
+      expect(response).toEqual({
+        ...unknownMethodResult,
+        message: "Some error from correct method",
+      } as Failure);
       expect(mockedStartRecording).toHaveBeenCalledTimes(1);
       expect(mockedStartRecording).toHaveBeenCalledWith(msg);
-      expect(JSON.stringify(response)).toEqual(
-        JSON.stringify({
-          ...unknownMethodResult,
-          message: "Some error from correct method",
-        } as Failure)
-      );
     });
   });
 });

--- a/src/rapidrec/callbacks.ts
+++ b/src/rapidrec/callbacks.ts
@@ -74,16 +74,17 @@ export async function onMessage(
     );
     sendResponse(response);
   } catch (err) {
-    console.error((err as Error).message);
     const response = {
       result: MethodResult.Failed,
       errCode: ErrorCode.Some,
       message: (err as Error).message,
     } as Failure;
-    console.log(
+
+    console.error(
       `callbacks onMessage, sendResponse as error ${JSON.stringify(response)}`
     );
     sendResponse(response);
+    return Promise.reject(response);
   }
 }
 
@@ -96,6 +97,7 @@ export async function onTabChange(newTabInfo: ActiveTabInfo): Promise<void> {
     } as BrowserTabChange);
   } catch (err) {
     console.error(`callbacks onTabChange error ${(err as Error).message}`);
+    throw err;
   }
 }
 
@@ -111,5 +113,6 @@ export async function onTabClosing(
     } as BrowserTabClosing);
   } catch (err) {
     console.log(`callbacks onTabClosing error ${(err as Error).message}`);
+    throw err;
   }
 }

--- a/src/rapidrec/rapidrec.ts
+++ b/src/rapidrec/rapidrec.ts
@@ -5,6 +5,7 @@
 import {
   BrowserTabChange,
   BrowserTabClosing,
+  Failure,
   Message,
   MessageResponse,
   MethodResult,
@@ -13,6 +14,7 @@ import {
   RecStop,
   Success,
 } from "./communication";
+import { ErrorCode } from "./errors";
 import { Injector, DeInjector } from "./injection";
 
 export enum State {
@@ -33,44 +35,69 @@ export class RapidRec {
     currentTab: 0,
   };
 
-  // TODO: Add try/catch below
-
   /* Public events */
   static async setMode(message: Message): Promise<MessageResponse> {
     console.log(`RapidRec setMode ${JSON.stringify(message)}`);
     message = message as RecSetMode;
 
-    switch (message.params.mode) {
-      case RecMode.ScreenOnly:
-        // Do nothing
-        break;
-      case RecMode.ScreenAndCam:
-        await Injector.cameraBubble(RapidRec.ctx.currentTab);
-        break;
-      default:
-        throw new Error(`Unknown record mode ${message.params.mode as string}`);
+    try {
+      switch (message.params.mode) {
+        case RecMode.ScreenOnly:
+          // Do nothing
+          break;
+        case RecMode.ScreenAndCam:
+          await Injector.cameraBubble(RapidRec.ctx.currentTab);
+          break;
+        default:
+          throw new Error(
+            `Unknown record mode ${message.params.mode as string}`
+          );
+      }
+      RapidRec.ctx.mode = message.params.mode;
+      return { result: MethodResult.Success } as Success;
+    } catch (err) {
+      return {
+        result: MethodResult.Failed,
+        errCode: ErrorCode.Some,
+        message: `RapidRec setMode: ${(err as Error).message}`,
+      } as Failure;
     }
-    RapidRec.ctx.mode = message.params.mode;
-    return { result: MethodResult.Success } as Success;
   }
 
   static async startRecording(message: Message): Promise<MessageResponse> {
     console.log(`RapidRec startRecording ${JSON.stringify(message)}`);
-    if (!RapidRec.ctx.mode) {
-      throw new Error("Current mode is `null`, can't start recording");
+
+    try {
+      if (!RapidRec.ctx.mode) {
+        throw new Error("Current mode is `null`, can't start recording");
+      }
+      await Injector.screenCapture(RapidRec.ctx.currentTab);
+      return { result: MethodResult.Success } as Success;
+    } catch (err) {
+      return {
+        result: MethodResult.Failed,
+        errCode: ErrorCode.Some,
+        message: `RapidRec startRecording: ${(err as Error).message}`,
+      } as Failure;
     }
-    await Injector.screenCapture(RapidRec.ctx.currentTab);
-    return { result: MethodResult.Success } as Success;
   }
 
   static async stopRecording(message: Message): Promise<MessageResponse> {
     console.log(`RapidRec stopRecording ${JSON.stringify(message)}`);
     message = message as RecStop;
 
-    await chrome.downloads.download({
-      url: message.params.downloadUrl,
-    });
-    return { result: MethodResult.Success } as Success;
+    try {
+      await chrome.downloads.download({
+        url: message.params.downloadUrl,
+      });
+      return { result: MethodResult.Success } as Success;
+    } catch (err) {
+      return {
+        result: MethodResult.Failed,
+        errCode: ErrorCode.Some,
+        message: `RapidRec stopRecording: ${(err as Error).message}`,
+      } as Failure;
+    }
   }
 
   /* Internal events */
@@ -78,27 +105,42 @@ export class RapidRec {
     console.log(`RapidRec handleTabChange ${JSON.stringify(message)}`);
     message = message as BrowserTabChange;
 
-    if (RapidRec.ctx.mode === RecMode.ScreenAndCam) {
-      if (RapidRec.ctx.currentTab) {
-        await DeInjector.cameraBubble(RapidRec.ctx.currentTab);
+    try {
+      if (RapidRec.ctx.mode === RecMode.ScreenAndCam) {
+        if (RapidRec.ctx.currentTab) {
+          await DeInjector.cameraBubble(RapidRec.ctx.currentTab);
+        }
+        await Injector.cameraBubble(message.params.tabId);
       }
-      await Injector.cameraBubble(message.params.tabId);
+      RapidRec.ctx.currentTab = message.params.tabId;
+      return { result: MethodResult.Success } as Success;
+    } catch (err) {
+      return {
+        result: MethodResult.Failed,
+        errCode: ErrorCode.Some,
+        message: `RapidRec handleTabChange: ${(err as Error).message}`,
+      } as Failure;
     }
-    RapidRec.ctx.currentTab = message.params.tabId;
-    return { result: MethodResult.Success } as Success;
   }
 
   static handleTabClosing(message: Message): Promise<MessageResponse> {
     console.log(`RapidRec handleTabClosing ${JSON.stringify(message)}`);
     message as BrowserTabClosing;
 
-    RapidRec.ctx.mode = null;
-    RapidRec.ctx.state = State.Idle;
-    RapidRec.ctx.currentTab = 0;
-
     // NOTE @imblowfish: Just a hint for compatibility with other functions
-    return new Promise((resolve) =>
-      resolve({ result: MethodResult.Success } as Success)
-    );
+    return new Promise((resolve) => {
+      try {
+        RapidRec.ctx.mode = null;
+        RapidRec.ctx.state = State.Idle;
+        RapidRec.ctx.currentTab = 0;
+        resolve({ result: MethodResult.Success } as Success);
+      } catch (err) {
+        resolve({
+          result: MethodResult.Failed,
+          errCode: ErrorCode.Some,
+          message: `RapidRec setMode: ${(err as Error).message}`,
+        } as Failure);
+      }
+    });
   }
 }


### PR DESCRIPTION
Closes #27

Starts from now:
`rapidrec` returns resolved promises only
`callbacks`send response to message sender and returns resolved or
rejected promise to the `background` script
And `background` script just shows a message in `console`
