### PR TITLE
Fixed showing/hiding camera bubble with two Chrome windows

### DIFF
--- a/src/handlers.ts
+++ b/src/handlers.ts
@@ -154,7 +154,10 @@ export async function handleWindowChange(args: MethodArgs): Promise<void> {
     return;
   }
 
-  const tabs = await chrome.tabs.query({ active: true });
+  const tabs = await chrome.tabs.query({
+    active: true,
+    windowId: args.newWindowId,
+  });
   await handleTabChange({ newTabId: tabs[0].id as number });
   await storage.set.currentWindowId(args.newWindowId);
 }

--- a/src/test/handlers.test.ts
+++ b/src/test/handlers.test.ts
@@ -192,11 +192,14 @@ test("handleOpenUserActiveWindow", async () => {
 });
 
 describe("handleWindowChange", () => {
-  test("Non recordingId or <= 0", async () => {
+  test("Is not equals to recordingId and >= 0", async () => {
     await handleWindowChange({ newWindowId: 10 });
 
     expect(storage.get.recordingWindowId).toHaveBeenCalled();
-    expect(chrome.tabs.query).toHaveBeenCalled();
+    expect(chrome.tabs.query).toHaveBeenCalledWith({
+      active: true,
+      windowId: 10,
+    });
     expect(storage.set.currentWindowId).toHaveBeenCalledWith(10);
   });
 


### PR DESCRIPTION
This PR fixes an issue with showing/hiding camera bubble when two Chrome windows are open.

The problem was in the `tabs.query` options where "active" was "true" but "windowId" wasn't set. Therefore `tabs.query` returned the current active tab in the previous window.