### PR TITLE
Reset current tab on tab close

### DIFF
--- a/src/handlers.ts
+++ b/src/handlers.ts
@@ -124,7 +124,13 @@ export async function handleTabChange(args: MethodArgs): Promise<void> {
 export async function handleTabClosing(args: MethodArgs): Promise<void> {
   console.log(`handleTabClosing(args=${JSON.stringify(args)})`);
 
-  await handleHideCameraBubble(args);
+  /* NOTE: We don't call `handleHideCameraBubble` because this method
+   *       tries to remove the script with camera bubble from current
+   *       tab, but at the time the close tab callback is called,
+   *       that tab is already closed and doesn't exist
+   */
+  await storage.set.cameraBubbleVisible(false);
+  await storage.set.recordingTabId(0);
 }
 
 export async function handleTabUpdated(_args: MethodArgs): Promise<void> {

--- a/src/test/handlers.test.ts
+++ b/src/test/handlers.test.ts
@@ -49,6 +49,7 @@ import {
   handleStartRecording,
   handleStopRecording,
   handleTabChange,
+  handleTabClosing,
   handleTabUpdated,
   handleWindowChange,
 } from "../handlers";
@@ -174,6 +175,13 @@ describe("handleTabChange", () => {
 
     expect(storage.set.currentTabId).not.toHaveBeenCalled();
   });
+});
+
+test("handleTabClosing", async () => {
+  await handleTabClosing({ closedTabId: 12 });
+
+  expect(storage.set.cameraBubbleVisible).toHaveBeenCalledWith(false);
+  expect(storage.set.recordingTabId).toHaveBeenCalledWith(0);
 });
 
 test("handleTabUpdated", async () => {


### PR DESCRIPTION
Closed #105
This PR added resetting the current tab on close and got rid of removing the camera bubble script because it throws an `No tab` error in that case