### PR TITLE
Fixed incorrect hiding of camera bubble when click hide in another ta…

### DIFF
--- a/src/handlers.ts
+++ b/src/handlers.ts
@@ -10,6 +10,7 @@ import { storage } from "./storage";
 
 async function setStorageDefaultValues() {
   await storage.set.currentTabId(0);
+  await storage.set.cameraBubbleTabId(0);
   await storage.set.recordingTabId(0);
   await storage.set.currentWindowId(0);
   await storage.set.recordingWindowId(0);
@@ -74,10 +75,12 @@ export async function handleDownloadRecording(args: MethodArgs): Promise<void> {
 export async function handleShowCameraBubble(_args: MethodArgs): Promise<void> {
   console.log("handleShowCameraBubble");
 
+  const currentTabId = await storage.get.currentTabId();
   await chrome.scripting.executeScript({
-    target: { tabId: await storage.get.currentTabId() },
+    target: { tabId: currentTabId },
     files: ["./cameraBubble.bundle.mjs"],
   });
+  await storage.set.cameraBubbleTabId(currentTabId);
   await storage.set.cameraBubbleVisible(true);
 }
 
@@ -85,11 +88,12 @@ export async function handleHideCameraBubble(_args: MethodArgs): Promise<void> {
   console.log("handleHideCameraBubble");
 
   await chrome.scripting.executeScript({
-    target: { tabId: await storage.get.currentTabId() },
+    target: { tabId: await storage.get.cameraBubbleTabId() },
     func: () => {
       document.getElementById("rapidrec-camera-bubble")?.remove();
     },
   });
+  await storage.set.cameraBubbleTabId(0);
   await storage.set.cameraBubbleVisible(false);
 }
 

--- a/src/storage.ts
+++ b/src/storage.ts
@@ -2,6 +2,7 @@ const storageImpl = chrome.storage.local;
 
 interface Context {
   currentTabId: number;
+  cameraBubbleTabId: number;
   recordingTabId: number;
   currentWindowId: number;
   recordingWindowId: number;
@@ -17,6 +18,17 @@ function setCurrentTabId(tabId: number): Promise<void> {
 async function getCurrentTabId(): Promise<number> {
   const { currentTabId } = await storageImpl.get("currentTabId");
   return currentTabId as number;
+}
+
+function setCameraBubbleTabId(tabId: number): Promise<void> {
+  return storageImpl.set({
+    cameraBubbleTabId: tabId,
+  } satisfies Partial<Context>);
+}
+
+async function getCameraBubbleTabId(): Promise<number> {
+  const { cameraBubbleTabId } = await storageImpl.get("cameraBubbleTabId");
+  return cameraBubbleTabId as number;
 }
 
 function setRecordingTabId(tabId: number): Promise<void> {
@@ -86,6 +98,7 @@ async function getMicrophoneAllowed(): Promise<boolean> {
 export const storage = {
   set: {
     currentTabId: setCurrentTabId,
+    cameraBubbleTabId: setCameraBubbleTabId,
     recordingTabId: setRecordingTabId,
     currentWindowId: setCurrentWindowId,
     recordingWindowId: setRecordingWindowId,
@@ -95,6 +108,7 @@ export const storage = {
   },
   get: {
     currentTabId: getCurrentTabId,
+    cameraBubbleTabId: getCameraBubbleTabId,
     recordingTabId: getRecordingTabId,
     currentWindowId: getCurrentWindowId,
     recordingWindowId: getRecordingWindowId,

--- a/src/test/storage.test.ts
+++ b/src/test/storage.test.ts
@@ -1,4 +1,16 @@
 import { jest } from "@jest/globals";
+
+const defaultValues = {
+  currentTabId: 1,
+  cameraBubbleTabId: 2,
+  recordingTabId: 3,
+  currentWindowId: 4,
+  recordingWindowId: 5,
+  recordingInProgress: true,
+  cameraBubbleVisible: true,
+  microphoneAllowed: false,
+};
+
 globalThis.chrome = {
   storage: {
     local: {
@@ -6,13 +18,14 @@ globalThis.chrome = {
       set: jest.fn().mockResolvedValue({}),
       // @ts-expect-error Chrome methods mocking
       get: jest.fn().mockResolvedValue({
-        currentTabId: 1,
-        recordingTabId: 2,
-        currentWindowId: 3,
-        recordingWindowId: 4,
-        recordingInProgress: true,
-        cameraBubbleVisible: true,
-        microphoneAllowed: false,
+        currentTabId: defaultValues.currentTabId,
+        cameraBubbleTabId: defaultValues.cameraBubbleTabId,
+        recordingTabId: defaultValues.recordingTabId,
+        currentWindowId: defaultValues.currentWindowId,
+        recordingWindowId: defaultValues.recordingWindowId,
+        recordingInProgress: defaultValues.recordingInProgress,
+        cameraBubbleVisible: defaultValues.cameraBubbleVisible,
+        microphoneAllowed: defaultValues.microphoneAllowed,
       }),
     },
   },
@@ -20,77 +33,113 @@ globalThis.chrome = {
 const { storage } = await import("../storage");
 
 test("currentTabId", async () => {
-  await storage.set.currentTabId(1);
+  await storage.set.currentTabId(defaultValues.currentTabId);
   // eslint-disable-next-line @typescript-eslint/unbound-method
-  expect(chrome.storage.local.set).toBeCalledWith({ currentTabId: 1 });
+  expect(chrome.storage.local.set).toBeCalledWith({
+    currentTabId: defaultValues.currentTabId,
+  });
 
-  await expect(storage.get.currentTabId()).resolves.toBe(1);
+  await expect(storage.get.currentTabId()).resolves.toBe(
+    defaultValues.currentTabId
+  );
   // eslint-disable-next-line @typescript-eslint/unbound-method
   expect(chrome.storage.local.get).toHaveBeenCalledWith("currentTabId");
 });
 
-test("recordingTabId", async () => {
-  await storage.set.recordingTabId(2);
+test("cameraBubbleTabId", async () => {
+  await storage.set.cameraBubbleTabId(defaultValues.cameraBubbleTabId);
   // eslint-disable-next-line @typescript-eslint/unbound-method
-  expect(chrome.storage.local.set).toBeCalledWith({ recordingTabId: 2 });
+  expect(chrome.storage.local.set).toBeCalledWith({
+    cameraBubbleTabId: defaultValues.cameraBubbleTabId,
+  });
 
-  await expect(storage.get.recordingTabId()).resolves.toBe(2);
+  await expect(storage.get.cameraBubbleTabId()).resolves.toBe(
+    defaultValues.cameraBubbleTabId
+  );
+  // eslint-disable-next-line @typescript-eslint/unbound-method
+  expect(chrome.storage.local.get).toHaveBeenCalledWith("cameraBubbleTabId");
+});
+
+test("recordingTabId", async () => {
+  await storage.set.recordingTabId(defaultValues.recordingTabId);
+  // eslint-disable-next-line @typescript-eslint/unbound-method
+  expect(chrome.storage.local.set).toBeCalledWith({
+    recordingTabId: defaultValues.recordingTabId,
+  });
+
+  await expect(storage.get.recordingTabId()).resolves.toBe(
+    defaultValues.recordingTabId
+  );
   // eslint-disable-next-line @typescript-eslint/unbound-method
   expect(chrome.storage.local.get).toHaveBeenCalledWith("recordingTabId");
 });
 
 test("currentWindowId", async () => {
-  await storage.set.currentWindowId(3);
+  await storage.set.currentWindowId(defaultValues.currentWindowId);
   // eslint-disable-next-line @typescript-eslint/unbound-method
-  expect(chrome.storage.local.set).toBeCalledWith({ currentWindowId: 3 });
+  expect(chrome.storage.local.set).toBeCalledWith({
+    currentWindowId: defaultValues.currentWindowId,
+  });
 
-  await expect(storage.get.currentWindowId()).resolves.toBe(3);
+  await expect(storage.get.currentWindowId()).resolves.toBe(
+    defaultValues.currentWindowId
+  );
   // eslint-disable-next-line @typescript-eslint/unbound-method
   expect(chrome.storage.local.get).toHaveBeenCalledWith("currentWindowId");
 });
 
 test("recordignWindowId", async () => {
-  await storage.set.recordingWindowId(4);
+  await storage.set.recordingWindowId(defaultValues.recordingWindowId);
   // eslint-disable-next-line @typescript-eslint/unbound-method
-  expect(chrome.storage.local.set).toBeCalledWith({ recordingWindowId: 4 });
+  expect(chrome.storage.local.set).toBeCalledWith({
+    recordingWindowId: defaultValues.recordingWindowId,
+  });
 
-  await expect(storage.get.recordingWindowId()).resolves.toBe(4);
+  await expect(storage.get.recordingWindowId()).resolves.toBe(
+    defaultValues.recordingWindowId
+  );
   // eslint-disable-next-line @typescript-eslint/unbound-method
   expect(chrome.storage.local.get).toHaveBeenCalledWith("recordingWindowId");
 });
 
 test("recordingInProgress", async () => {
-  await storage.set.recordingInProgress(true);
+  await storage.set.recordingInProgress(defaultValues.recordingInProgress);
   // eslint-disable-next-line @typescript-eslint/unbound-method
   expect(chrome.storage.local.set).toBeCalledWith({
-    recordingInProgress: true,
+    recordingInProgress: defaultValues.recordingInProgress,
   });
 
-  await expect(storage.get.recordingInProgress()).resolves.toBe(true);
+  await expect(storage.get.recordingInProgress()).resolves.toBe(
+    defaultValues.recordingInProgress
+  );
   // eslint-disable-next-line @typescript-eslint/unbound-method
   expect(chrome.storage.local.get).toHaveBeenCalledWith("recordingInProgress");
 });
 
 test("cameraBubbleVisible", async () => {
-  await storage.set.cameraBubbleVisible(true);
+  await storage.set.cameraBubbleVisible(defaultValues.cameraBubbleVisible);
   // eslint-disable-next-line @typescript-eslint/unbound-method
   expect(chrome.storage.local.set).toBeCalledWith({
-    cameraBubbleVisible: true,
+    cameraBubbleVisible: defaultValues.cameraBubbleVisible,
   });
 
-  await expect(storage.get.cameraBubbleVisible()).resolves.toBe(true);
+  await expect(storage.get.cameraBubbleVisible()).resolves.toBe(
+    defaultValues.cameraBubbleVisible
+  );
   // eslint-disable-next-line @typescript-eslint/unbound-method
   expect(chrome.storage.local.get).toHaveBeenCalledWith("cameraBubbleVisible");
 });
 
 test("microphoneAllowed", async () => {
-  await storage.set.microphoneAllowed(false);
+  await storage.set.microphoneAllowed(defaultValues.microphoneAllowed);
   // eslint-disable-next-line @typescript-eslint/unbound-method
   expect(chrome.storage.local.set).toBeCalledWith({
-    microphoneAllowed: false,
+    microphoneAllowed: defaultValues.microphoneAllowed,
   });
 
-  await expect(storage.get.microphoneAllowed()).resolves.toBe(false);
+  await expect(storage.get.microphoneAllowed()).resolves.toBe(
+    defaultValues.microphoneAllowed
+  );
   // eslint-disable-next-line @typescript-eslint/unbound-method
   expect(chrome.storage.local.get).toHaveBeenCalledWith("microphoneAllowed");
 });


### PR DESCRIPTION
Fixed #117

Previously, if you clicked `Show Bubble`, went to a new tab, and clicked `Hide Bubble`, nothing happened because `handleCameraBubbleHide` was trying to remove the script from the current tab, not the tab it was created on

I fixed this with a new storage variable `cameraBubbleTabId` which contains the id of the tab where the script was injected