### PR TITLE
Fixes `@emotion/react` warning on multiple camera bubble injection

### DIFF
--- a/src/handlers.ts
+++ b/src/handlers.ts
@@ -91,6 +91,24 @@ export async function handleHideCameraBubble(_args: MethodArgs): Promise<void> {
     target: { tabId: await storage.get.cameraBubbleTabId() },
     func: () => {
       document.getElementById("rapidrec-camera-bubble")?.remove();
+      /* NOTE: `@emotion/react` library used by `@mui` as a style library sets the value in
+       *       `globalThis` to define double import. This is ok in case of normal use of `@mui`
+       *       in web UI.
+       *       But when show/hide the camera bubble via Chrome code injection, we expect
+       *       the component using `@mui` to be injected and removed multiple times.
+       *       Setting the value to `globalThis` in such a situation results in warning,
+       *       which is displayed to the user in the `Errors` tab for extension.
+       *       For this purpose, such a hack was invented
+       *
+       *       More info: https://github.com/imblowfish/rapidrec-chrome-extension/issues/118
+       */
+      const re = new RegExp(/__EMOTION_REACT_\d+__/);
+      const emotionKey = Object.keys(globalThis).find((key) => re.test(key));
+      if (!emotionKey) {
+        return;
+      }
+      // @ts-expect-error `globalThis` uses `any`, we're trying to set the key to `string`, TS doesn't like that
+      globalThis[emotionKey] = false;
     },
   });
   await storage.set.cameraBubbleTabId(0);


### PR DESCRIPTION
Fixed #118

As I described in the issue, `@emotion/react` uses `globalThis` and set guard to prevent multiple import

```js
var globalContext = // $FlowIgnore
    typeof globalThis !== 'undefined' ? globalThis // eslint-disable-line no-undef
    : isBrowser ? window : __webpack_require__.g;
var globalKey = "__EMOTION_REACT_" + pkg.version.split('.')[0] + "__";

if (globalContext[globalKey]) {
  console.warn('You are loading @emotion/react when it is already loaded. Running ' + 'multiple instances may cause problems. This can happen if multiple ' + 'versions are used, or if multiple builds of the same version are ' + 'used.');
}

globalContext[globalKey] = true;
```

But when we expect the component will be injected and removed multiple times we should disable this value by ourself