### PR TITLE
Fixed invalidated context error when disabling the extension

### DIFF
--- a/src/components/camera_bubble.tsx
+++ b/src/components/camera_bubble.tsx
@@ -39,7 +39,14 @@ const StartStopRecording = () => {
         .then((value: boolean) => {
           setInProgress(value);
         })
-        .catch((err) => console.error(err));
+        .catch((err) => {
+          if ((err as Error).message != "Extension context invalidated.") {
+            console.error(err);
+            return;
+          }
+          clearInterval(interval);
+          console.log("Looks like extension was disabled, interval removed");
+        });
     }, 500);
 
     return () => {

--- a/src/components/popup_menu.tsx
+++ b/src/components/popup_menu.tsx
@@ -11,7 +11,14 @@ const ShowHideCameraBubble = () => {
       storage.get
         .cameraBubbleVisible()
         .then(setIsVisible)
-        .catch((err) => console.error(err));
+        .catch((err) => {
+          if ((err as Error).message != "Extension context invalidated.") {
+            console.error(err);
+            return;
+          }
+          clearInterval(interval);
+          console.log("Looks like extension was disabled, interval removed");
+        });
     }, 500);
 
     return () => {
@@ -42,7 +49,14 @@ const TurnOnTurnOffMic = () => {
       storage.get
         .microphoneAllowed()
         .then(setMicAllowed)
-        .catch((err) => console.error(err));
+        .catch((err) => {
+          if ((err as Error).message != "Extension context invalidated.") {
+            console.error(err);
+            return;
+          }
+          clearInterval(interval);
+          console.log("Looks like extension was disabled, interval removed");
+        });
     }, 500);
 
     return () => {
@@ -75,7 +89,14 @@ const StartStopRecording = () => {
       storage.get
         .recordingInProgress()
         .then(setInProgress)
-        .catch((err) => console.error(err));
+        .catch((err) => {
+          if ((err as Error).message != "Extension context invalidated.") {
+            console.error(err);
+            return;
+          }
+          clearInterval(interval);
+          console.log("Looks like extension was disabled, interval removed");
+        });
     }, 500);
 
     return () => {


### PR DESCRIPTION
Fixed #119

The problem occurred due to the fact that when removing a component from page with `chrome.scripting.executeScript`, the callback returned from `useEffect` is not called

Then there are still an async `setInterval` function. I fixed this by checking the returned error message, and if the error indicates that the extension context is lost, then the interval is removed