### PR TITLE
Removed `console.error` on error screen sharing error

### DIFF
--- a/src/handlers.ts
+++ b/src/handlers.ts
@@ -1,6 +1,7 @@
 import {
   BrowserTabChangeArgs,
   BrowserWindowChangeArgs,
+  CancelRecordingArgs,
   DownloadRecordingArgs,
   MethodArgs,
   builder,
@@ -84,8 +85,10 @@ export async function handleDeleteRecording(_args: MethodArgs): Promise<void> {
   );
 }
 
-export async function handleCancelRecording(_args: MethodArgs): Promise<void> {
-  console.log("handleCancelRecording()");
+export async function handleCancelRecording(args: MethodArgs): Promise<void> {
+  args = args as CancelRecordingArgs;
+
+  console.log(`handleCancelRecording, reason: ${args.reason}`);
 
   await chrome.tabs.remove(await storage.get.recordingTabId());
   await storage.set.recordingTabId(0);

--- a/src/messaging.ts
+++ b/src/messaging.ts
@@ -23,6 +23,7 @@ export enum Method {
   BrowserWindowChange,
 }
 
+export type CancelRecordingArgs = { reason: string };
 export type DownloadRecordingArgs = { downloadUrl: string };
 export type BrowserTabChangeArgs = { newTabId: number };
 export type BrowserTabClosingArgs = { closedTabId: number };
@@ -30,6 +31,7 @@ export type TabStopMediaRecorderArgs = { downloadRecording: boolean };
 export type BrowserWindowChangeArgs = { newWindowId: number };
 
 export type MethodArgs =
+  | CancelRecordingArgs
   | DownloadRecordingArgs
   | BrowserTabChangeArgs
   | BrowserTabClosingArgs
@@ -78,9 +80,12 @@ function buildDeleteRecording(): Message {
   };
 }
 
-function buildCancelRecording(): Message {
+function buildCancelRecording(reason: string): Message {
   return {
     method: Method.CancelRecording,
+    args: {
+      reason,
+    },
   };
 }
 

--- a/src/scripts/screen_sharing.ts
+++ b/src/scripts/screen_sharing.ts
@@ -112,10 +112,9 @@ class RecorderV2 {
 
   #onStop() {
     if (!this.#downloadOnStop) {
-      console.log(
-        "Recording isn't downloaded because the user decided to delete it"
-      );
-      sender.send(builder.cancelRecording()).catch((err) => console.error(err));
+      sender
+        .send(builder.cancelRecording("User decided to delete recording"))
+        .catch((err) => console.error(err));
       return;
     }
     const downloadUrl = URL.createObjectURL(
@@ -173,6 +172,5 @@ try {
 
   await sender.send(builder.openUserActiveWindow());
 } catch (err) {
-  console.error(`Can't start screen sharing ${(err as Error).message}`);
-  await sender.send(builder.cancelRecording());
+  await sender.send(builder.cancelRecording((err as Error).message));
 }

--- a/src/test/callbacks.test.ts
+++ b/src/test/callbacks.test.ts
@@ -115,7 +115,7 @@ describe("onMessage", () => {
   test("Correct CancelRecording message", async () => {
     let response: MessageResponse | undefined;
 
-    await onMessage(builder.cancelRecording(), {}, (resp) => {
+    await onMessage(builder.cancelRecording("some reason"), {}, (resp) => {
       response = resp;
     });
 

--- a/src/test/messaging.test.ts
+++ b/src/test/messaging.test.ts
@@ -52,8 +52,11 @@ describe("builder", () => {
   });
 
   test("buildCancelRecording", () => {
-    expect(builder.cancelRecording()).toEqual({
+    expect(builder.cancelRecording("some reason")).toEqual({
       method: Method.CancelRecording,
+      args: {
+        reason: "some reason",
+      },
     } satisfies Message);
   });
 


### PR DESCRIPTION
Closed #129 

In this PR screen sharing cancel reason was moved to `handlers.ts` file

It's bad that all errors will be printed as simple log and maybe in the future I should add some filter, but now I decided to just move logs from injected UI to web worker