### PR TITLE
Added a new ss check in case the extension was installed but no tabs were open

### DIFF
--- a/src/handlers.ts
+++ b/src/handlers.ts
@@ -263,6 +263,13 @@ export async function handleOpenUserActiveWindow(
 ): Promise<void> {
   console.log("handleOpenUserActiveWindow()");
 
+  const currentWindowId = await storage.get.currentWindowId();
+  if (currentWindowId <= 0) {
+    console.warn(
+      "No data on the last window opened, most likely because the extension was recently reloaded"
+    );
+    return;
+  }
   await chrome.windows.update(await storage.get.currentWindowId(), {
     focused: true,
   });

--- a/src/test/handlers.test.ts
+++ b/src/test/handlers.test.ts
@@ -359,16 +359,29 @@ test("handleTabUpdated", async () => {
   expect(mockedStorage.get.cameraBubbleVisible).toHaveBeenCalled();
 });
 
-test("handleOpenUserActiveWindow", async () => {
-  await handleOpenUserActiveWindow({});
+describe("handleOpenUserActiveWindow", () => {
+  test("currentWindowId > 0", async () => {
+    await handleOpenUserActiveWindow({});
 
-  expect(mockedStorage.get.currentWindowId).toHaveBeenCalled();
-  expect(chrome.windows.update).toHaveBeenCalledWith(
-    defaultValues.currentWindowId,
-    {
-      focused: true,
-    }
-  );
+    expect(mockedStorage.get.currentWindowId).toHaveBeenCalled();
+    expect(chrome.windows.update).toHaveBeenCalledWith(
+      defaultValues.currentWindowId,
+      {
+        focused: true,
+      }
+    );
+  });
+
+  test("currentWindowId <= 0", async () => {
+    mockedStorage.get.currentWindowId = (
+      jest.fn() as jest.Mock<() => Promise<number>>
+    ).mockResolvedValue(-1);
+
+    await handleOpenUserActiveWindow({});
+
+    expect(mockedStorage.get.currentWindowId).toHaveBeenCalled();
+    expect(chrome.windows.update).not.toHaveBeenCalled();
+  });
 });
 
 describe("handleWindowChange", () => {


### PR DESCRIPTION
Closed #131 

I fixed the error message but I can't open the last active window because there is no way in the Chrome API to hide the current window. Any attempt to determine the current window on `chrome://*` tabs results in a value of `-1`

Based on this, I decided to add a new check and leave the screen sharing window if the user starts recording immediately after installing the extension.